### PR TITLE
Fix RPA Workflow Name bug

### DIFF
--- a/OpenFlowNodeRED/src/nodered/nodes/rpa.html
+++ b/OpenFlowNodeRED/src/nodered/nodes/rpa.html
@@ -98,7 +98,8 @@ Send payload as data to a robot, requesting it to run the selected Workflow
         defaults: {
             queue: { value: "", required: true },
             workflow: { value: "", required: true },
-            localqueue: { value: "" }
+            localqueue: { value: "" },
+            name: { value: "" }
         },
         inputs: 1,
         outputs: 3,


### PR DESCRIPTION
Fix RPA Workflow Name bug to allow the Name of an RPA Workflow node to be changed.