### PR TITLE
Allow targetid and workflowid for RPA Workflow nodes

### DIFF
--- a/OpenFlowNodeRED/src/nodered/nodes/rpa.html
+++ b/OpenFlowNodeRED/src/nodered/nodes/rpa.html
@@ -87,7 +87,9 @@ Active everytime a trigger gets triggered on a robot
     </div>
 </script>
 <script type="text/x-red" data-help-name="rpa workflow">
-Send payload as data to a robot, requesting it to run the selected Workflow
+Send payload as data to a robot, requesting it to run the selected Workflow.<br>
+You can set Workflow using msg.workflowid<br>
+You can set Target using msg.targetid<br>
 </script>
 <script type="text/javascript">
     RED.nodes.registerType('rpa workflow', {
@@ -96,8 +98,8 @@ Send payload as data to a robot, requesting it to run the selected Workflow
         paletteLabel: 'robot',
         icon: "open_rpa_white.png",
         defaults: {
-            queue: { value: "", required: true },
-            workflow: { value: "", required: true },
+            queue: { value: "" },
+            workflow: { value: "" },
             localqueue: { value: "" },
             name: { value: "" }
         },

--- a/OpenFlowNodeRED/src/nodered/nodes/rpa_nodes.ts
+++ b/OpenFlowNodeRED/src/nodered/nodes/rpa_nodes.ts
@@ -157,19 +157,29 @@ export class rpa_workflow_node {
     async oninput(msg: any) {
         try {
             this.node.status({});
+            let targetid = NoderedUtil.IsNullEmpty(this.config.queue) || this.config.queue === 'none' ? msg.targetid : this.config.queue;
+            let workflowid = NoderedUtil.IsNullEmpty(this.config.workflow) ? msg.workflowid : this.config.workflow;
             var correlationId = Math.random().toString(36).substr(2, 9);
             this.messages[correlationId] = msg;
             if (msg.payload == null || typeof msg.payload == "string" || typeof msg.payload == "number") {
                 msg.payload = { "data": msg.payload };
             }
+            if(NoderedUtil.IsNullEmpty(targetid)) {
+                this.node.status({ fill: "red", shape: "dot", text: "robot is mandatory" });
+                return;
+            }
+            if(NoderedUtil.IsNullEmpty(workflowid)) {
+                this.node.status({ fill: "red", shape: "dot", text: "workflow is mandatory" });
+                return;
+            }
             var rpacommand = {
                 command: "invoke",
-                workflowid: this.config.workflow,
+                workflowid: workflowid,
                 jwt: msg.jwt,
                 data: { payload: msg.payload }
             }
             this.node.status({ fill: "blue", shape: "dot", text: "Robot running..." });
-            this.con.SendMessage(JSON.stringify(rpacommand), this.config.queue, correlationId, true);
+            this.con.SendMessage(JSON.stringify(rpacommand), targetid, correlationId, true);
         } catch (error) {
             NoderedUtil.HandleError(this, error);
             try {


### PR DESCRIPTION
Extend the same functionality as available in the Assign Workflow node to be available in RPA Workflow nodes.