### PR TITLE
Create timeouts for RabbitMQ messages to OpenRPA robots

### DIFF
--- a/OpenFlow/src/Config.ts
+++ b/OpenFlow/src/Config.ts
@@ -64,6 +64,14 @@ export class Config {
     public static nodered_domain_schema: string = Config.getEnv("nodered_domain_schema", ""); // also sent to website
     public static nodered_initial_liveness_delay: number = parseInt(Config.getEnv("nodered_initial_liveness_delay", "60"));
 
+    // Environment variables to set a prefix for RabbitMQs Dead Letter Exchange, Dead Letter Routing Key,
+    // Dead Letter Queue, and Message Time to Live - to enable timeouts for RabbitMQ messages
+    // These values must be the same for OpenFlowNodeRED and OpenFlow, or will cause errors when asserting queues
+    public static amqp_dlx_prefix: string = Config.getEnv("amqp_dlx_prefix", "DLX.");
+    public static amqp_dlrk_prefix: string = Config.getEnv("amqp_dlrk_prefix", "dlx.");
+    public static amqp_dlq_prefix: string = Config.getEnv("amqp_dlq_prefix", "dlq.");
+    public static amqp_message_ttl: number = parseInt(Config.getEnv("amqp_message_ttl", "20000"));
+
     public static baseurl(): string {
         var result: string = "";
         if (Config.tls_crt != '' && Config.tls_key != '') {

--- a/OpenFlow/src/amqp_consumer.ts
+++ b/OpenFlow/src/amqp_consumer.ts
@@ -1,6 +1,7 @@
 import * as winston from "winston";
 import * as amqplib from "amqplib";
 import * as url from "url";
+import { Config } from "./Config";
 
 
 // tslint:disable-next-line: class-name
@@ -22,7 +23,17 @@ export class amqp_consumer {
         this.conn = await amqplib.connect(this.connectionstring);
         this.conn.on("error", () => null);
         this.channel = await this.conn.createChannel();
-        this._ok = await this.channel.assertQueue(this.queue, { durable: false, autoDelete: autoDelete });
+        // Assert queue with additional arguments for dead letter exchange (for timed out messages)
+        // These arguments have to match the arguments set in amqp_publisher.ts in the OpenFlowNodeRED src folder
+        this._ok = await this.channel.assertQueue(this.queue, {
+            durable: false,
+            autoDelete: autoDelete,
+            arguments: {
+                'x-dead-letter-exchange': Config.amqp_dlx_prefix + this.queue,
+                'x-dead-letter-routing-key': Config.amqp_dlrk_prefix + this.queue,
+                'x-message-ttl': Config.amqp_message_ttl
+            }
+        });
         await this.channel.consume(this.queue, (msg) => { this.OnMessage(me, msg); }, { noAck: autoack });
         this._logger.info("Connected to " + new URL(this.connectionstring).hostname);
     }

--- a/OpenFlowNodeRED/src/Config.ts
+++ b/OpenFlowNodeRED/src/Config.ts
@@ -39,6 +39,14 @@ export class Config {
     public static tls_ca: string = Config.getEnv("tls_ca", "");
     public static tls_passphrase: string = Config.getEnv("tls_passphrase", "");
 
+    // Environment variables to set a prefix for RabbitMQs Dead Letter Exchange, Dead Letter Routing Key,
+    // Dead Letter Queue, and Message Time to Live - to enable timeouts for RabbitMQ messages
+    // These values must be the same for OpenFlowNodeRED and OpenFlow, or will cause errors when asserting queues
+    public static amqp_dlx_prefix: string = Config.getEnv("amqp_dlx_prefix", "DLX.");
+    public static amqp_dlrk_prefix: string = Config.getEnv("amqp_dlrk_prefix", "dlx.");
+    public static amqp_dlq_prefix: string = Config.getEnv("amqp_dlq_prefix", "dlq.");
+    public static amqp_message_ttl: number = parseInt(Config.getEnv("amqp_message_ttl", "20000"));
+
 
     public static baseurl(): string {
         if (NoderedUtil.IsNullEmpty(Config.domain)) {

--- a/OpenFlowNodeRED/src/amqp_publisher.ts
+++ b/OpenFlowNodeRED/src/amqp_publisher.ts
@@ -1,6 +1,7 @@
 import * as winston from "winston";
 import * as amqplib from "amqplib";
 import { NoderedUtil } from "./nodered/nodes/NoderedUtil";
+import { Config } from './Config';
 
 
 interface IHashTable<T> {
@@ -65,10 +66,42 @@ export class amqp_publisher {
         if (this.channel != null && this.channel != undefined) { await this.channel.close(); this.channel = null; }
         if (this.conn != null && this.conn != undefined) { await this.conn.close(); this.conn = null; }
     }
-    SendMessage(msg: string, queue: string, correlationId: string, sendreply: boolean): void {
+    async SendMessage(msg: string, queue: string, correlationId: string, sendreply: boolean): Promise<void> {
         if (correlationId == null || correlationId == "") { correlationId = this.generateUuid(); }
         this._logger.info("SendMessage " + msg);
+
         if (sendreply) {
+            // Before sending the message, need to assert the exchange and queue to handle timed out messages
+            // This is done via a dead letter exchange, and dead letter queue
+            const dlx = await this.channel.assertExchange(Config.amqp_dlx_prefix + queue, 'topic', { durable: false });
+            const dlq = await this.channel.assertQueue(Config.amqp_dlq_prefix + queue, { durable: false });
+            // Bind the dead letter queue to the dead letter exchange, routing with the dead letter routing key
+            await this.channel.bindQueue(dlq.queue, dlx.exchange, Config.amqp_dlrk_prefix + queue);
+
+            // Must also consume messages in the dead letter queue, to catch messages that have timed out
+            await this.channel.consume(dlq.queue, msg => {
+                // This is the function to run when the dead letter (timed out) message is picked up
+                var data = JSON.parse(msg.content.toString());
+                // Change the command and return back to the correct queue (replyTo) to be handled
+                // Clear x-first-death-reason header
+                msg.properties.headers["x-first-death-reason"] = null;
+                // Set command to timeout to be handled when collected from the node's queue
+                data.command = "timeout";
+                // Resend message, this time to the reply queue for the correct node (replyTo)
+                this.SendMessage(JSON.stringify(data), msg.properties.replyTo, msg.properties.correlationId, false);
+            },
+                { noAck: true });
+
+            // Need to assert new queue first to ensure it has the timeout arguments added to it
+            await this.channel.assertQueue(queue, {
+                durable: false,
+                arguments: {
+                    'x-dead-letter-exchange': Config.amqp_dlx_prefix + queue,
+                    'x-dead-letter-routing-key': Config.amqp_dlrk_prefix + queue,
+                    'x-message-ttl': Config.amqp_message_ttl
+                }
+            });
+
             this.channel.sendToQueue(queue, Buffer.from(msg), { correlationId: correlationId, replyTo: this._ok.queue });
         } else {
             this.channel.sendToQueue(queue, Buffer.from(msg), { correlationId: correlationId });

--- a/OpenFlowNodeRED/src/nodered/nodes/rpa_nodes.ts
+++ b/OpenFlowNodeRED/src/nodered/nodes/rpa_nodes.ts
@@ -117,9 +117,10 @@ export class rpa_workflow_node {
             var command = data.command;
             result.jwt = data.jwt;
             var correlationId = msg.properties.correlationId;
+
             if (correlationId != null && this.messages[correlationId] != null) {
                 result = this.messages[correlationId];
-                if (command == "invokecompleted" || command == "invokefailed" || command == "invokeaborted" || command == "error") {
+                if (command == "invokecompleted" || command == "invokefailed" || command == "invokeaborted" || command == "error" || command == "timeout") {
                     delete this.messages[correlationId];
                 }
             }
@@ -134,7 +135,7 @@ export class rpa_workflow_node {
                 console.log("********************");
                 this.node.send(result);
             }
-            else if (command == "invokefailed" || command == "invokeaborted" || command == "error") {
+            else if (command == "invokefailed" || command == "invokeaborted" || command == "error" || command == "timeout") {
                 result.payload = data;
                 if (data.user != null) result.user = data.user;
                 if (result.payload == null || result.payload == undefined) { result.payload = {}; }
@@ -164,11 +165,11 @@ export class rpa_workflow_node {
             if (msg.payload == null || typeof msg.payload == "string" || typeof msg.payload == "number") {
                 msg.payload = { "data": msg.payload };
             }
-            if(NoderedUtil.IsNullEmpty(targetid)) {
+            if (NoderedUtil.IsNullEmpty(targetid)) {
                 this.node.status({ fill: "red", shape: "dot", text: "robot is mandatory" });
                 return;
             }
-            if(NoderedUtil.IsNullEmpty(workflowid)) {
+            if (NoderedUtil.IsNullEmpty(workflowid)) {
                 this.node.status({ fill: "red", shape: "dot", text: "workflow is mandatory" });
                 return;
             }
@@ -176,6 +177,9 @@ export class rpa_workflow_node {
                 command: "invoke",
                 workflowid: workflowid,
                 jwt: msg.jwt,
+                // Adding expiry to the rpacommand as a timestamp for when the RPA message is expected to timeout from the message queue
+                // Currently set to 20 seconds into the future
+                expiry: Math.floor((new Date().getTime()) / 1000) + Config.amqp_message_ttl,
                 data: { payload: msg.payload }
             }
             this.node.status({ fill: "blue", shape: "dot", text: "Robot running..." });


### PR DESCRIPTION
**Create Timeouts for RabbitMQ messages to OpenRPA robots**

When a queue is asserted via amqp_publisher for Nodered, or amqp_consumer for OpenRPA via OpenFlow, additional arguments have been added to this queue for creation:
'x-dead-letter-exchange' = the exchange handling timed out messages
'x-dead-letter-routing-key' = the key used by the exchange to route it to the correct queue
'x-message-ttl' = the time in milliseconds before timing out.

Also added an additional assertQueue in NodeRed to create the Dead Letter Queue, and a consumer for the dead letter queue to pick up timed out messages in Nodered.

When the message is consumed, a function is called to send a new message to the replyTo queue with a timeout command, to handle informing that node in nodered that the message has timed out.